### PR TITLE
Create Navigation Bar

### DIFF
--- a/BombApp.xcodeproj/project.pbxproj
+++ b/BombApp.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		868D16092A80DE7400C6D712 /* UIColor+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868D16082A80DE7400C6D712 /* UIColor+App.swift */; };
 		868D160B2A80F24B00C6D712 /* DelaGothicOne-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 868D160A2A80F24B00C6D712 /* DelaGothicOne-Regular.ttf */; };
 		868D160D2A80F2AD00C6D712 /* UIFont+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 868D160C2A80F2AD00C6D712 /* UIFont+App.swift */; };
+		E79A26832A84207D00ECCACF /* Extension + UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79A26822A84207D00ECCACF /* Extension + UIViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -69,6 +70,7 @@
 		868D16082A80DE7400C6D712 /* UIColor+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+App.swift"; sourceTree = "<group>"; };
 		868D160A2A80F24B00C6D712 /* DelaGothicOne-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "DelaGothicOne-Regular.ttf"; sourceTree = "<group>"; };
 		868D160C2A80F2AD00C6D712 /* UIFont+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+App.swift"; sourceTree = "<group>"; };
+		E79A26822A84207D00ECCACF /* Extension + UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIViewController.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -248,6 +250,7 @@
 				867B18682A83D7C600F7CAAA /* UIStackView+App.swift */,
 				867B18692A83D7C600F7CAAA /* UIView+App.swift */,
 				867B18562A83D34500F7CAAA /* CustomAlertViewController.swift */,
+				E79A26822A84207D00ECCACF /* Extension + UIViewController.swift */,
 			);
 			path = UIConstants;
 			sourceTree = "<group>";
@@ -413,6 +416,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E79A26832A84207D00ECCACF /* Extension + UIViewController.swift in Sources */,
 				867B18632A83D7A600F7CAAA /* StopButton.swift in Sources */,
 				40DB97052A83F90C008EE64F /* GaneEndView.swift in Sources */,
 				868D16002A80DD6100C6D712 /* CategoryViewController.swift in Sources */,

--- a/BombApp/Application/SceneDelegate.swift
+++ b/BombApp/Application/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = MainViewController()
+        window?.rootViewController = UINavigationController(rootViewController: MainViewController())
         window?.makeKeyAndVisible()
     }
 

--- a/BombApp/CategoryModule/Controllers/CategoryViewController.swift
+++ b/BombApp/CategoryModule/Controllers/CategoryViewController.swift
@@ -42,20 +42,22 @@ class CategoryViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let backChevron = UIBarButtonItem(image: UIImage(systemName: "chevron.left"), style: .plain, target: self, action: nil)
-        backChevron.tintColor = .blackColor
-        let categoreView = UILabel()
-        categoreView.text = "Категории"
-        categoreView.textColor = .purpleColor
-        categoreView.font = UIFont(name: "DelaGothicOne-Regular", size: 30)
+//        let backChevron = UIBarButtonItem(image: UIImage(systemName: "chevron.left"), style: .plain, target: self, action: nil)
+//        backChevron.tintColor = .blackColor
+//        let categoreView = UILabel()
+//        categoreView.text = "Категории"
+//        categoreView.textColor = .purpleColor
+//        categoreView.font = UIFont(name: "DelaGothicOne-Regular", size: 30)
         
-        self.navigationItem.titleView = categoreView
-        navigationItem.leftBarButtonItem = backChevron
+//        self.navigationItem.titleView = categoreView
+//        navigationItem.leftBarButtonItem = backChevron
         addGradientBackground(topColor: UIColor.yellow, bottomColor: UIColor.orange)
-        categoreView.addSubview(collectionView)
+//        categoreView.addSubview(collectionView)
+        view.addSubview(collectionView)
         collectionView.dataSource = self
         collectionView.delegate = self
         Quiestion.generateQuestions()
+        setupNavigationBar()
     }
     
     override func viewWillLayoutSubviews() {
@@ -79,6 +81,13 @@ class CategoryViewController: UIViewController {
             alertController.modalTransitionStyle = .crossDissolve
             self.present(alertController, animated: true)
         }
+    }
+    
+    private func setupNavigationBar() {
+        createCustomNavigationBar()
+        
+        let sceneTitleView = createCustomTitleView(sceneTitle: "Категории")
+        navigationItem.titleView = sceneTitleView
     }
     
     private func makeConstraints() {

--- a/BombApp/GameModule/Controllers/GameViewController.swift
+++ b/BombApp/GameModule/Controllers/GameViewController.swift
@@ -16,6 +16,7 @@ class GameViewController: UIViewController {
         
         updateUI()
         setConstraints()
+        setupNavigationBar()
     }
     
     private func updateUI() {
@@ -26,9 +27,22 @@ class GameViewController: UIViewController {
 //        }
     }
     
+    private func setupNavigationBar() {
+        createCustomNavigationBar()
+        
+        let sceneTitleView = createCustomTitleView(sceneTitle: "Игра")
+        let gameStopButton = createCustomButton(selector: #selector(stopOrResumeGame))
+        navigationItem.titleView = sceneTitleView
+        navigationItem.rightBarButtonItems = [gameStopButton]
+    }
+    
     @objc func startButtonPressed() {
         print("button is hidden and title changed")
         gameStartView.startButton.isHidden = true
+    }
+    
+    @objc func stopOrResumeGame() {
+        print("Game stop/resume")
     }
 }
 

--- a/BombApp/GameModule/Views/GameStartView.swift
+++ b/BombApp/GameModule/Views/GameStartView.swift
@@ -9,15 +9,15 @@ import UIKit
 
 class GameStartView: UIView {
     
-    private let titleLabel = UILabel(text: "Игра",
-                                     font: .delaGothicOneRegular30(),
-                                     color: .purpleColor)
+//    private let titleLabel = UILabel(text: "Игра",
+//                                     font: .delaGothicOneRegular30(),
+//                                     color: .purpleColor)
     private let gameLabel = UILabel(text: "Нажмите “Запустить” чтобы начать игру",
                                     font: .delaGothicOneRegular32(),
                                     color: .purpleColor)
     
-    private let backButton = BackButton()
-    private let stopButton = StopButton()
+//    private let backButton = BackButton()
+//    private let stopButton = StopButton()
     let startButton = PurpleButton(text: "Запустить")
     
     private let bombImageView: UIImageView = {
@@ -44,9 +44,9 @@ class GameStartView: UIView {
     private func updateUI() {
         backgroundColor = .clear
         translatesAutoresizingMaskIntoConstraints = false
-        addSubview(backButton)
-        addSubview(titleLabel)
-        addSubview(stopButton)
+//        addSubview(backButton)
+//        addSubview(titleLabel)
+//        addSubview(stopButton)
         addSubview(gameLabel)
         addSubview(bombImageView)
         addSubview(startButton)
@@ -86,25 +86,26 @@ extension GameStartView {
     private func setConstraints() {
         NSLayoutConstraint.activate([
         
-            backButton.heightAnchor.constraint(equalToConstant: 19),
-            backButton.widthAnchor.constraint(equalToConstant: 11),
-            backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            backButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            
-            titleLabel.heightAnchor.constraint(equalToConstant: 40),
-            titleLabel.widthAnchor.constraint(equalToConstant: 92),
-            titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            titleLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 0),
-            
-            stopButton.heightAnchor.constraint(equalToConstant: 38),
-            stopButton.widthAnchor.constraint(equalToConstant: 37),
-            stopButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            stopButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+//            backButton.heightAnchor.constraint(equalToConstant: 19),
+//            backButton.widthAnchor.constraint(equalToConstant: 11),
+//            backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+//            backButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+//            
+//            titleLabel.heightAnchor.constraint(equalToConstant: 40),
+//            titleLabel.widthAnchor.constraint(equalToConstant: 92),
+//            titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+//            titleLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 0),
+//            
+//            stopButton.heightAnchor.constraint(equalToConstant: 38),
+//            stopButton.widthAnchor.constraint(equalToConstant: 37),
+//            stopButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+//            stopButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
             
             gameLabel.heightAnchor.constraint(equalToConstant: 115),
             gameLabel.widthAnchor.constraint(equalToConstant: 329),
             gameLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            gameLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 40),
+//            gameLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 40),
+            gameLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: 40),
             
             bombImageView.heightAnchor.constraint(equalToConstant: 350),
             bombImageView.widthAnchor.constraint(equalToConstant: 310),

--- a/BombApp/MainModule/Controllers/MainViewController.swift
+++ b/BombApp/MainModule/Controllers/MainViewController.swift
@@ -97,15 +97,18 @@ class MainViewController: UIViewController {
     }
     
     @objc func startGameButtonTapped() {
-        
+        let gameViewController = GameViewController()
+        navigationController?.pushViewController(gameViewController, animated: true)
     }
     
     @objc func categoryButtonTapped() {
-        
+        let categoryViewController = CategoryViewController()
+        navigationController?.pushViewController(categoryViewController, animated: true)
     }
     
     @objc func rulesButtonTapped() {
-        
+        let rulesViewController = RulesViewController()
+        navigationController?.pushViewController(rulesViewController, animated: true)
     }
     
     

--- a/BombApp/RulesModule/Controllers/RulesViewController.swift
+++ b/BombApp/RulesModule/Controllers/RulesViewController.swift
@@ -11,8 +11,15 @@ class RulesViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        setupNavigationBar()
+    }
+    
+    private func setupNavigationBar() {
+        createCustomNavigationBar()
+        
+        let sceneTitleView = createCustomTitleView(sceneTitle: "Помощь")
+        navigationItem.titleView = sceneTitleView
     }
     
 

--- a/BombApp/UIConstants/Extension + UIViewController.swift
+++ b/BombApp/UIConstants/Extension + UIViewController.swift
@@ -1,0 +1,44 @@
+//
+//  Extension + UIViewController.swift
+//  BombApp
+//
+//  Created by Daria Arisova on 09.08.2023.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    func createCustomNavigationBar() {
+        navigationController?.navigationBar.isTranslucent = true
+        navigationController?.navigationBar.tintColor = UIColor(red: 0.05, green: 0.05, blue: 0.05, alpha: 1.00)
+        navigationController?.navigationBar.topItem?.title = " " //some kind of magic remove back arrow btn title O_o
+    }
+    
+    func createCustomTitleView(sceneTitle: String) -> UIView {
+        let view = UIView()
+//        view.frame = CGRect(x: 0, y: 0, width: 280, height: 41)
+        let sceneTitleLabel = UILabel(
+            text: sceneTitle,
+            font: UIFont.delaGothicOneRegular30()!,
+            color: .purpleColor
+        )
+        
+        view.addSubview(sceneTitleLabel)
+        NSLayoutConstraint.activate([
+            sceneTitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            sceneTitleLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        
+        return view
+    }
+    
+    func createCustomButton(selector: Selector) -> UIBarButtonItem {
+        let stopButton = StopButton()
+        stopButton.addTarget(self, action: selector, for: .touchUpInside)
+        
+        let menuBarItem = UIBarButtonItem(customView: stopButton)
+        
+        return menuBarItem
+    }
+}


### PR DESCRIPTION
Добавлен Navigation Bar с кастомными методами для индивидуальной настройки перехода между вьюшками (вынесены в файл Extension + UIViewController в папке UIConstants). На данный момент связаны главный экран с экранами игры, категорий и настроек. 
У navigation bar сделаны constraints только для тайтла (по X и Y осям), кнопки назад и stopGame расположились сами по дефолту. Но если сравнить с макетом Жени, то он еще делал отступы для этих кнопок (специально заскринила для наглядности navigationBar и под ним верстку от Жени). Мы с ним попробовали сделать констрейты - у нас не вышло и мы решили, что без них navigation bar выглядит тоже нормально))
<img width="467" alt="Screenshot 2023-08-10 at 12 27 53 AM" src="https://github.com/zcredi/BombApp/assets/37332990/b2891a5b-50eb-47b2-bb2b-12881b953955">
